### PR TITLE
Add Package Cap Warnings to Analyze.py

### DIFF
--- a/reporting/analyze.py
+++ b/reporting/analyze.py
@@ -1013,7 +1013,7 @@ class Analyze(object):
         self.add_to_analysis_dict(key_col=self.missing_ad_rate,
                                   message=msg, data=df.to_dict())
         
-    def check_package_cap(self, df):
+        def check_package_cap(self, df):
         '''
         This function checks if a package used for capping has reached its cap
         Prints to logfile
@@ -1022,55 +1022,79 @@ class Analyze(object):
         temp_package_cap -> column name we are capping on from rawfile
         'Planned Net Cost - TEMP' -> how much we are capping, taken from rawfile
         '''
+        df = cal.net_cost_calculation(df)
         if cal.MetricCap().config:
-            for cfg in cal.MetricCap().config:
-                c = cal.MetricCap().config[cfg]
-            pdf = cal.MetricCap().get_cap_file(c)
+            cap_file = cal.MetricCap()
+            for cfg in cap_file.config:
+                c = cap_file.config[cfg]
+            pdf = cap_file.get_cap_file(c)
             df = df.append(pdf)
-            temp_package_cap = pdf.columns.tolist()
-            temp_package_cap = temp_package_cap[0]
-
+            temp_package_cap = c[cap_file.proc_dim]
             df = df[[temp_package_cap, 'Planned Net Cost - TEMP', vmc.cost]]
             df = df.groupby([temp_package_cap])
-            df = df.apply(lambda x: 0 if x['Planned Net Cost - TEMP'].sum() == 0 else x[vmc.cost].sum() / x['Planned Net Cost - TEMP'].sum())
+            df = df.apply(lambda x: 0 if
+            x['Planned Net Cost - TEMP'].sum() == 0
+            else x[vmc.cost].sum() /
+                 x['Planned Net Cost - TEMP'].sum())
             f_df = df[df >= 1]
-
             if f_df.empty:
                 delivery_msg = 'No Packages have exceeded their cap'
                 logging.info(delivery_msg)
+                self.add_to_analysis_dict(key_col=self.package_cap,
+                                          message=delivery_msg)
             else:
                 del_p = f_df.apply(lambda x: "{0:.2f}%".format(x * 100))
                 delivery_msg = 'The following packages have delivered in full: '
                 logging.info('{}\n{}'.format(delivery_msg, del_p))
+                data = del_p.reset_index().rename(columns={0: 'Cap'})
+                self.add_to_analysis_dict(key_col=self.package_cap,
+                                          message=delivery_msg,
+                                          data=data.to_dict())
+                o_df = f_df[f_df > 1.5]
+                if not o_df.empty:
+                    del_p = o_df.apply(lambda x: "{0:.2f}%".format(x * 100))
+                    delivery_msg = 'The following packages have over-delivered:'
+                    logging.info('{}\n{}'.format(delivery_msg, del_p))
+                    data = del_p.reset_index().rename(columns={0: 'Cap'})
+                    self.add_to_analysis_dict(key_col=self.package_cap,
+                                              message=delivery_msg,
+                                              data=data.to_dict())
 
     def check_package_vendor(self, df):
         '''
         Warns if the package capfile will affect multiple vendors
         creates dataframe grouped by cap and vendor
-        counts unique members, if there are more vendors than there are caps, raise a warning
+        counts unique members,
+        if there are more vendors than there are caps, raise a warning
         '''
         if cal.MetricCap().config:
-            for cfg in cal.MetricCap().config:
-                c = cal.MetricCap().config[cfg]
-            pdf = cal.MetricCap().get_cap_file(c)
+            cap_file = cal.MetricCap()
+            for cfg in cap_file.config:
+                c = cap_file.config[cfg]
+            pdf = cap_file.get_cap_file(c)
             df = df.append(pdf)
-            temp_package_cap = pdf.columns.tolist()
-            temp_package_cap = temp_package_cap[0]
-
-            df = df[[dctc.VEN, vmc.vendorkey, dctc.PN, temp_package_cap, 'Planned Net Cost - TEMP', vmc.cost]]
+            temp_package_cap = c[cap_file.proc_dim]
+            df = df[[dctc.VEN, vmc.vendorkey, dctc.PN, temp_package_cap,
+                     'Planned Net Cost - TEMP', vmc.cost]]
             df = df.groupby([temp_package_cap, dctc.VEN])
             df = df.size().reset_index(name='count')
             df = df[[temp_package_cap, dctc.VEN]]
-
+            df = df[df[temp_package_cap].isin(pdf[temp_package_cap])]
             unique_caps = len(pd.unique(df[temp_package_cap]))
             unique_vendors = len(pd.unique(df[dctc.VEN]))
             if unique_caps < unique_vendors:
-                delivery_msg = 'WARNING: The package you are capping on may have multiple vendors associated: '
+                delivery_msg = 'One or more of the packages ' \
+                               'you are capping on is associated ' \
+                               'with multiple vendors'
                 caps_msg = 'Number of unique packages:  '
                 vend_msg = 'Number of unique vendors:   '
-                logging.info('{}\n{}'.format(delivery_msg, df))
+                logging.warning('{}\n{}'.format(delivery_msg, df))
                 logging.info('{}{}'.format(caps_msg, unique_caps))
                 logging.info('{}{}'.format(vend_msg, unique_vendors))
+            else:
+                delivery_msg = "All packages are capping on a single vendor"
+            self.add_to_analysis_dict(key_col=self.package_vendor,
+                                      message=delivery_msg, data=df.to_dict())
 
     def find_in_analysis_dict(self, key, param=None, param_2=None,
                               split_col=None, filter_col=None, filter_val=None):


### PR DESCRIPTION
Create check_pacakage_cap function that displays if a package has reached it's expected cap.
Create check_package_vendor function that gives a warning when a provided cap may be affecting multiple vendors