### PR TITLE
Guarantee non-duplicated Misc columns on dict order modal load.

### DIFF
--- a/reporting/dictionary.py
+++ b/reporting/dictionary.py
@@ -65,6 +65,7 @@ class Dict(object):
             if len(autodicord) < max_placement_name_length:
                 length_diff = max_placement_name_length - len(autodicord)
                 autodicord.extend([dctc.MIS] * length_diff)
+                autodicord = list(utl.rename_duplicates(autodicord))
         for i, value in enumerate(autodicord):
             if include_index:
                 col_name = '{}-{}'.format(i, value)

--- a/reporting/utils.py
+++ b/reporting/utils.py
@@ -281,3 +281,18 @@ def give_df_default_format(df, columns=None):
             format_map = '{:,.0f}'.format
         df[col] = df[col].map(format_map)
     return df
+
+
+def rename_duplicates(old):
+    seen = {}
+    for x in old:
+        if x in seen:
+            seen[x] += 1
+            new_val = '{} {}'.format(x, seen[x])
+            if new_val in old:
+                yield '{}-{}'.format(new_val, 1)
+            else:
+                yield new_val
+        else:
+            seen[x] = 0
+            yield x


### PR DESCRIPTION
Addresses bug where order table loaded incorrectly due to duplicated mpMisc df column names.