### PR TITLE
Allow merge of transformed datasources

### DIFF
--- a/reporting/dcapi.py
+++ b/reporting/dcapi.py
@@ -16,7 +16,7 @@ base_url = 'https://www.googleapis.com/dfareporting'
 class DcApi(object):
     default_fields = [
         'campaign', 'campaignId', 'site', 'placement',
-        'date', 'placementId', 'creative', 'ad']
+        'date', 'placementId', 'creative', 'ad', 'creativeId']
     default_metrics = [
         'impressions', 'clicks', 'clickRate',
         'activeViewViewableImpressions',

--- a/reporting/vendormatrix.py
+++ b/reporting/vendormatrix.py
@@ -864,12 +864,13 @@ def vm_update_rule_check(vm, vm_col):
     return vm
 
 
-def df_transform(df, transform):
+def df_transform(df, transform, skip_transforms=[]):
     if str(transform) == 'nan':
         return df
     split_transform = transform.split(':::')
     for t in split_transform:
-        df = df_single_transform(df, t)
+        if t.split('::')[0] not in skip_transforms:
+            df = df_single_transform(df, t)
     return df
 
 
@@ -910,6 +911,17 @@ def df_single_transform(df, transform):
             ven_param = matrix.vendor_set(merge_file)
             ds = DataSource(merge_file, matrix.vm_rules_dict, **ven_param)
             merge_df = ds.get_raw_df_before_transform()
+            if not merge_df.empty and merge_df is not None:
+                merge_df = df_transform(merge_df, ds.p[vmc.transform],
+                                        skip_transforms=['Merge',
+                                                         'MergeReplace',
+                                                         'MergeReplaceExclude']
+                                        )
+        if merge_df is None or merge_df.empty:
+            logging.error('Unable to execute merge transform. Requested merge '
+                          'source {} returned empty dataframe.'
+                          .format(merge_file))
+            return df
         merge_cols = transform[2:]
         left_merge = merge_cols[::2]
         right_merge_full = merge_cols[1::2]


### PR DESCRIPTION
Allow datasources called by merge transforms to undergo their own transformations (excluding merges). Update DCM API to include Creative ID.