### PR TITLE
Allow relation component columns in auto dictionary order

### DIFF
--- a/reporting/analyze.py
+++ b/reporting/analyze.py
@@ -544,17 +544,15 @@ class Analyze(object):
             file_name = source.p[vmc.filename]
             first_row = source.p[vmc.firstrow]
             missing_cols = []
-            if os.path.exists(file_name):
-                tdf = utl.import_read_csv(file_name, nrows=first_row + 5)
+            tdf = utl.import_read_csv(file_name, nrows=first_row + 5)
+            if not tdf.empty:
                 tdf = utl.first_last_adj(tdf, first_row, 0)
-                cols = list(tdf.columns)
-                active_metrics = source.get_active_metrics()
-                for k, v in active_metrics.items():
-                    for c in v:
-                        if c not in cols:
-                            missing_cols.append({k: c})
-            else:
-                cols = []
+            cols = list(tdf.columns)
+            active_metrics = source.get_active_metrics()
+            for k, v in active_metrics.items():
+                for c in v:
+                    if c not in cols:
+                        missing_cols.append({k: c})
             data_dict = {vmc.vendorkey: [source.key], self.raw_columns: [cols],
                          'missing': [missing_cols]}
             df = df.append(pd.DataFrame(data_dict),

--- a/reporting/dictionary.py
+++ b/reporting/dictionary.py
@@ -82,19 +82,13 @@ class Dict(object):
                    for k, v in rc.rc[dctc.AUTO].items() if str(v) != 'nan'}
         rc_delimit = {rc.rc[dctc.KEY][k]: v.split('::')[1::2]
                       for k, v in rc.rc[dctc.AUTO].items() if str(v) != 'nan'}
+        mixed_formats = False
         for rc_key in rc_auto:
-            mixed_format = [x for x in error.columns if rc_key+comb_key in x]
-            if mixed_format:
-                logging.warning('Mixed relational column format detected. '
-                                'Output may not be as expected. Please use '
-                                'EITHER "mpSize" OR "mpCreative:::0:::_" '
-                                'style column naming conventions, not both.')
+            trad_format = [x for x in error.columns if rc_key+comb_key in x]
             idx_modifier = 0
             for idx, rc_component in enumerate(rc_auto[rc_key]):
                 component_cols = [x for x in error.columns if rc_component in
                                   x]
-                if not component_cols:
-                    continue
                 bald_component = False
                 for col in component_cols:
                     split_col = col.split(comb_key)
@@ -115,7 +109,15 @@ class Dict(object):
                         )
                     error[translated_col] = error[col].astype('U')
                     error.drop([col], axis=1, inplace=True)
-                idx_modifier += len(component_cols) - 1
+                if component_cols:
+                    idx_modifier += len(component_cols) - 1
+                    if trad_format:
+                        mixed_formats = True
+        if mixed_formats:
+            logging.warning('Mixed relational column format detected. '
+                            'Output may not be as expected. Please '
+                            'use EITHER "mpSize" OR "mpCreative:::0:::_" '
+                            'style column naming conventions, not both.')
         return error
 
     def auto(self, err, autodicord, placement):

--- a/reporting/dictionary.py
+++ b/reporting/dictionary.py
@@ -149,9 +149,9 @@ class Dict(object):
                       for k, v in rc.rc[dctc.AUTO].items() if str(v) != 'nan'}
         for col in final_cols:
             ind = [int(x.split(comb_key)[1]) for x in comb_cols if col in x]
-            i_min = 0
+            i_delimit_min = 0
             if col in error.columns:
-                i_min = -1
+                i_delimit_min = -1
             delimit_idx = 0
             for i in range(max(ind) + 1):
                 cur_col = [x for x in comb_cols
@@ -160,7 +160,7 @@ class Dict(object):
                     if col in rc_delimit:
                         cur_delimit = cur_col[0].split(comb_key)[2]
                         if (cur_delimit == rc_delimit[col][delimit_idx]
-                                and i > i_min):
+                                and i > i_delimit_min):
                             delimit_idx += 1
                 else:
                     try:
@@ -171,7 +171,7 @@ class Dict(object):
                     fill_col = '{}:::{}:::{}'.format(col, i, delimit_str)
                     comb_cols += [fill_col]
                     error[fill_col] = 0
-                    if i > i_min:
+                    if i > i_delimit_min:
                         delimit_idx += 1
         for col in sorted(comb_cols, key=lambda x: int(x.split(comb_key)[1])):
             final_col = col.split(comb_key)[0]

--- a/reporting/dictionary.py
+++ b/reporting/dictionary.py
@@ -106,29 +106,27 @@ class Dict(object):
             i_min = 0
             if col in error.columns:
                 i_min = -1
-            delim_idx = 0
+            delimit_idx = 0
             for i in range(max(ind) + 1):
                 cur_col = [x for x in comb_cols
                            if comb_key.join([col, str(i)]) in x]
                 if cur_col:
                     if col in rc_delimit:
                         cur_delimit = cur_col[0].split(comb_key)[2]
-                        if (cur_delimit == rc_delimit[col][delim_idx]
+                        if (cur_delimit == rc_delimit[col][delimit_idx]
                                 and i > i_min):
-                            delim_idx += 1
+                            delimit_idx += 1
                 else:
                     try:
-                        delimit_str = rc_delimit[col][delim_idx]
-                    except KeyError:
+                        delimit_str = rc_delimit[col][delimit_idx]
+                    except (KeyError, IndexError):
                         delimit_str = [x for x in comb_cols if col in x][0]
                         delimit_str = delimit_str.split(comb_key)[2]
                     fill_col = '{}:::{}:::{}'.format(col, i, delimit_str)
-                    print(fill_col)
                     comb_cols += [fill_col]
                     error[fill_col] = 0
                     if i > i_min:
-                        delim_idx += 1
-        print(comb_cols)
+                        delimit_idx += 1
         for col in sorted(comb_cols, key=lambda x: int(x.split(comb_key)[1])):
             final_col = col.split(comb_key)[0]
             delimit_str = col.split(comb_key)[2]

--- a/reporting/dictionary.py
+++ b/reporting/dictionary.py
@@ -148,11 +148,13 @@ class Dict(object):
         rc_delimit = rc.get_auto_delims()
         component_dict = {}
         valid_values = []
+        all_rel_cols = []
         for rc_key in rc_auto:
             start_idx = 0
             component_dict[rc_key] = {comp: [] for comp in rc_auto[rc_key]}
             key_cols = [col for col in columns
                         if col.split(self.comb_key)[0] == rc_key]
+            all_rel_cols.extend(key_cols)
             for idx, comp in enumerate(rc_auto[rc_key]):
                 lead_delim = None
                 trail_delim = None
@@ -162,6 +164,7 @@ class Dict(object):
                     trail_delim = rc_delimit[rc_key][idx]
                 rel_cols = [col for col in columns
                             if col.split(self.comb_key)[0] == comp]
+                all_rel_cols.extend(rel_cols)
                 if rel_cols:
                     first_index = 0
                     check_cols = rel_cols
@@ -214,7 +217,7 @@ class Dict(object):
             valid_values.extend([x for col in component_dict for sublist in
                                  component_dict[col].values() for x in
                                  sublist])
-            component_dict[bad_value] = [x for x in columns if x not in
+            component_dict[bad_value] = [x for x in all_rel_cols if x not in
                                          valid_values]
         return component_dict
 

--- a/reporting/vendormatrix.py
+++ b/reporting/vendormatrix.py
@@ -764,7 +764,8 @@ class DataSource(object):
                                    self.p[vmc.autodicplace],
                                    include_index=include_index,
                                    include_full_name=include_full_name)
-        error = dic.translate_relation_cols(error, to_component=True)
+        error = dic.translate_relation_cols(error, to_component=True,
+                                            fix_bad_delim=False)
         return error
 
     def get_and_merge_dictionary(self, df):

--- a/reporting/vendormatrix.py
+++ b/reporting/vendormatrix.py
@@ -764,6 +764,7 @@ class DataSource(object):
                                    self.p[vmc.autodicplace],
                                    include_index=include_index,
                                    include_full_name=include_full_name)
+        error = dic.translate_relation_to_component(error)
         return error
 
     def get_and_merge_dictionary(self, df):

--- a/reporting/vendormatrix.py
+++ b/reporting/vendormatrix.py
@@ -758,13 +758,17 @@ class DataSource(object):
     def get_dict_order_df(self, include_index=True, include_full_name=False):
         self.df = self.get_raw_df()
         dic = dct.Dict()
+        rc = dct.RelationalConfig()
+        rc.read(dctc.filename_rel_config)
+        rc_auto_tuple = rc.get_auto_tuple()
         err = er.ErrorReport(self.df, dic, self.p[vmc.placement],
                              self.p[vmc.filenameerror])
         error = dic.split_error_df(err, self.p[vmc.autodicord],
                                    self.p[vmc.autodicplace],
                                    include_index=include_index,
                                    include_full_name=include_full_name)
-        error = dic.translate_relation_cols(error, to_component=True,
+        error = dic.translate_relation_cols(error, rc_auto_tuple,
+                                            to_component=True,
                                             fix_bad_delim=False)
         return error
 

--- a/reporting/vendormatrix.py
+++ b/reporting/vendormatrix.py
@@ -772,8 +772,12 @@ class DataSource(object):
         dic = dct.Dict(self.p[vmc.filenamedict])
         err = er.ErrorReport(df, dic, self.p[vmc.placement],
                              self.p[vmc.filenameerror])
+        rc = dct.RelationalConfig()
+        rc.read(dctc.filename_rel_config)
+        rc_auto_tuple = rc.get_auto_tuple()
         dic.auto_functions(err=err, autodicord=self.p[vmc.autodicord],
-                           placement=self.p[vmc.autodicplace])
+                           placement=self.p[vmc.autodicplace],
+                           rc_auto=rc_auto_tuple)
         df = dic.merge(df, dctc.FPN)
         return df
 

--- a/reporting/vendormatrix.py
+++ b/reporting/vendormatrix.py
@@ -764,7 +764,7 @@ class DataSource(object):
                                    self.p[vmc.autodicplace],
                                    include_index=include_index,
                                    include_full_name=include_full_name)
-        error = dic.translate_relation_to_component(error)
+        error = dic.translate_relation_cols(error, to_component=True)
         return error
 
     def get_and_merge_dictionary(self, df):

--- a/test_processor.py
+++ b/test_processor.py
@@ -1,8 +1,11 @@
 import os
+import string
+import pytest
 import numpy as np
 import pandas as pd
 import reporting.utils as utl
 import reporting.vmcolumns as vmc
+import reporting.dictionary as dct
 import reporting.dictcolumns as dctc
 
 
@@ -61,3 +64,156 @@ class TestUtils:
 
 class TestApis:
     pass
+
+
+class TestDictionary:
+    dic = dct.Dict()
+    mock_rc_auto = ({dctc.TAR: [dctc.TB, dctc.DT1, dctc.GT]},
+                    {dctc.TAR: ['_', '_']})
+
+    def construct_empty_sort(self):
+        auto = self.mock_rc_auto[0]
+        empty_sort = {key: {comp: [] for comp in auto[key]} for key in auto}
+        return empty_sort
+
+    @pytest.mark.parametrize(
+        "columns, sorted_cols, bad_delim, missing, bad_value", [
+            ([], {}, True, False, False),
+            (['mpTargeting:::0:::_', 'mpData Type 1', 'mpTargeting:::2:::_'],
+             {dctc.TAR: {dctc.TB: ['mpTargeting:::0:::_'],
+                         dctc.DT1: ['mpData Type 1'],
+                         dctc.GT: ['mpTargeting:::2:::_']}},
+             True, False, False),
+            (['mpTargeting:::0:::_', 'mpData Type 1:::0:::-',
+              'mpTargeting:::2:::_'],
+             {dctc.TAR: {dctc.TB: ['mpTargeting:::0:::_'],
+                         dctc.DT1: ['mpData Type 1:::0:::-'],
+                         dctc.GT: ['mpTargeting:::2:::_']}},
+             True, False, False),
+            (['mpTargeting:::0:::_', 'mpData Type 1:::0:::-',
+              'mpTargeting:::2:::_'],
+             {dctc.TAR: {dctc.TB: ['mpTargeting:::0:::_'],
+                         dctc.GT: ['mpTargeting:::2:::_']}},
+             False, False, False),
+            (['mpTargeting:::0:::_', 'mpTargeting:::2:::_'],
+             {dctc.TAR: {dctc.TB: ['mpTargeting:::0:::_'],
+                         dctc.GT: ['mpTargeting:::2:::_'],
+                         'missing': ['mpTargeting:::1:::_']}},
+             True, True, False),
+            (['mpTargeting:::0:::_', 'mpData Type 1:::1:::_',
+              'mpTargeting:::2:::_'],
+             {dctc.TAR: {dctc.TB: ['mpTargeting:::0:::_'],
+                         dctc.GT: ['mpTargeting:::2:::_']},
+              'bad_values': ['mpData Type 1:::1:::_']},
+             True, False, True)
+        ],
+        ids=['empty', 'standard', 'bad_delim', 'no_bad_delim', 'missing',
+             'bad_value']
+    )
+    def test_sort_relation_cols(self, columns, sorted_cols, bad_delim,
+                                missing, bad_value):
+        df = pd.DataFrame(columns=columns)
+        output = self.dic.sort_relation_cols(df.columns, self.mock_rc_auto,
+                                             keep_bad_delim=bad_delim,
+                                             return_missing=missing,
+                                             return_bad_values=bad_value)
+        expected = self.construct_empty_sort()
+        for key in sorted_cols:
+            if type(sorted_cols[key]) != dict:
+                expected[key] = sorted_cols[key]
+            else:
+                for comp in sorted_cols[key]:
+                    expected[key][comp] = sorted_cols[key][comp]
+        assert output == expected
+
+    @pytest.mark.parametrize(
+        "columns, expected, bad_delim", [
+            ([], {}, True),
+            (['mpTargeting:::0:::_', 'mpData Type 1:::0:::_',
+              'mpTargeting:::2:::_'],
+             {'mpTargeting:::0:::_': 'mpTargeting Bucket:::0:::_',
+              'mpData Type 1:::0:::_': 'mpTargeting:::1:::_',
+              'mpTargeting:::2:::_': 'mpGenre Targeting:::0:::_'},
+             True),
+            (['mpTargeting:::0:::_', 'mpData Type 1:::0:::-',
+              'mpTargeting:::2:::_'],
+             {'mpTargeting:::0:::_': 'mpTargeting Bucket:::0:::_',
+              'mpData Type 1:::0:::-': 'mpTargeting:::1:::_',
+              'mpTargeting:::2:::_': 'mpGenre Targeting:::0:::_'},
+             True),
+            (['mpTargeting:::0:::_', 'mpData Type 1:::0:::-',
+              'mpTargeting:::2:::_'],
+             {'mpTargeting:::0:::_': 'mpTargeting Bucket:::0:::_',
+              'mpTargeting:::2:::_': 'mpGenre Targeting:::0:::_'},
+             False)
+        ],
+        ids=['empty', 'standard', 'bad_delim', 'no_bad_delim']
+    )
+    def test_get_relation_translations(self, columns, expected, bad_delim):
+        df = pd.DataFrame(columns=columns)
+        output = self.dic.get_relation_translations(df.columns,
+                                                    self.mock_rc_auto,
+                                                    fix_bad_delim=bad_delim)
+        assert output == expected
+
+    @pytest.mark.parametrize(
+        'columns, expected_cols, bad_delim, component', [
+            ([], [], True, False),
+            (['mpTargeting:::0:::_', 'mpData Type 1:::0:::-',
+              'mpTargeting:::2:::_'],
+             ['mpTargeting:::0:::_', 'mpTargeting:::1:::_',
+              'mpTargeting:::2:::_'],
+             True, False),
+            (['mpTargeting:::0:::_', 'mpData Type 1:::0:::-',
+              'mpTargeting:::2:::_'],
+             ['mpTargeting:::0:::_', 'mpData Type 1:::0:::-',
+              'mpTargeting:::2:::_'],
+             False, False),
+            (['mpTargeting:::0:::_', 'mpData Type 1:::0:::-',
+              'mpTargeting:::2:::_'],
+             ['mpTargeting Bucket:::0:::_', 'mpData Type 1:::0:::-',
+              'mpGenre Targeting:::0:::_'],
+             True, True),
+            ([dctc.MIS, dctc.MIS2], [dctc.MIS, dctc.MIS2], True, False)
+        ],
+        ids=['empty', 'bad_delim', 'no_bad_delim', 'to_component',
+             'non_relation']
+    )
+    def test_translate_relation_cols(self, columns, expected_cols, bad_delim,
+                                     component):
+        df = pd.DataFrame(columns=columns)
+        output = self.dic.translate_relation_cols(df, self.mock_rc_auto,
+                                                  fix_bad_delim=bad_delim,
+                                                  to_component=component)
+        expected = pd.DataFrame(columns=expected_cols)
+        pd.testing.assert_frame_equal(output, expected)
+
+    @pytest.mark.parametrize(
+        'columns, expected_data', [
+            ([], {}),
+            (['mpTargeting:::0:::_', 'mpData Type 1:::0:::-',
+              'mpTargeting:::2:::_'],
+             {dctc.TAR: ['a_b_c']}),
+            (['mpTargeting:::0:::_', 'mpData Type 1:::1:::-',
+              'mpTargeting:::3:::_'],
+             {dctc.TAR: ['a_0-b_c']}),
+            (['mpTargeting:::0:::_', 'mpData Type 1:::1:::_',
+              'mpTargeting:::3:::_'],
+             {dctc.TAR: ['a_0_0_c']}),
+            (['mpTargeting:::0:::_', 'mpData Type 1:::0:::-',
+              'mpTargeting:::2:::_', dctc.MIS],
+             {dctc.TAR: ['a_b_c'], dctc.MIS: ['d']}),
+            (['mpTargeting:::0:::_', 'mpTargeting Bucket:::0:::_',
+              'mpTargeting:::2:::_'],
+             {dctc.TAR: ['b_0_c']})
+        ],
+        ids=['empty', 'bad_delim', 'missing', 'bad_value', 'non_relation',
+             'duplicate']
+    )
+    def test_auto_combine(self, columns, expected_data):
+        df = pd.DataFrame()
+        for i, col in enumerate(columns):
+            df[col] = [string.ascii_lowercase[i]]
+        output = self.dic.auto_combine(df, self.mock_rc_auto)
+        expected = pd.DataFrame(expected_data)
+        pd.testing.assert_frame_equal(output, expected, check_like=True)


### PR DESCRIPTION
Allow values like 'mpSize', 'mpAd Type', etc. as input in auto dictionary order.