### PR TITLE
Brandtracker proc update

### DIFF
--- a/reporting/analyze.py
+++ b/reporting/analyze.py
@@ -55,6 +55,7 @@ class Analyze(object):
     package_vendor_bad = 'package_vendor_bad'
     cap_name = 'cap_name'
     change_auto_order = 'change_auto_order'
+    brandtracker_imports = 'brandtracker_imports'
     analysis_dict_file_name = 'analysis_dict.json'
     analysis_dict_key_col = 'key'
     analysis_dict_data_col = 'data'

--- a/reporting/vendormatrix.py
+++ b/reporting/vendormatrix.py
@@ -511,7 +511,8 @@ class ImportConfig(object):
                  old_import_dict[self.account_id]) and
                 (import_dict[self.filter] == old_import_dict[self.filter])):
             params = self.get_default_params(import_dict[self.key])
-            if import_dict[self.account_id]:
+            if (import_dict[self.account_id]
+                    or import_dict[self.key] in vmc.no_account_apis):
                 self.make_new_config(params, file_name,
                                      import_dict[self.account_id],
                                      import_dict[self.filter])


### PR DESCRIPTION
Add analyze key for brandtracker import table. Prevent unnecessary duplication for no_account_apis on import update.