### PR TITLE
fixed conditional in QuantCast API

### DIFF
--- a/reporting/qtapi.py
+++ b/reporting/qtapi.py
@@ -114,7 +114,7 @@ class QtApi(object):
         params = {'from': sd, 'to': ed}
         for i in range(1,10):
             r = requests.post(req_url, headers=self.header, json=params)
-            if r.json()['data']:
+            if 'data' in r.json():
                 tdf = pd.DataFrame(r.json()['data'])
                 logging.info('Data downloaded, returning df')
                 return tdf

--- a/reporting/qtapi.py
+++ b/reporting/qtapi.py
@@ -112,7 +112,15 @@ class QtApi(object):
         sd, ed = self.format_dates(sd, ed)
         logging.info('Getting data from {} to {}'.format(sd, ed))
         params = {'from': sd, 'to': ed}
-        r = requests.post(req_url, headers=self.header, json=params)
-        tdf = pd.DataFrame(r.json()['data'])
-        logging.info('Data downloaded, returning df')
-        return tdf
+        for i in range(1,10):
+            r = requests.post(req_url, headers=self.header, json=params)
+            if r.json()['data']:
+                tdf = pd.DataFrame(r.json()['data'])
+                logging.info('Data downloaded, returning df')
+                return tdf
+            else:
+                logging.warning('Could not retrieve data, retrying:'
+                                '{}'.format(r.json()))
+        logging.warning('Failed to retrieve data'
+                        '{}'.format(r.json()))
+        return pd.DataFrame()

--- a/reporting/szkapi.py
+++ b/reporting/szkapi.py
@@ -92,14 +92,18 @@ class SzkApi(object):
     def set_headers(self):
         self.headers = {'api-key': self.api_key}
         data = {'username': self.username, 'password': self.password}
-        r = self.make_request(
-            self.login_url, method='POST', data=json.dumps(data),
-            headers=self.headers)
-        if 'result' not in r.json():
-            logging.warning('Could not set headers with error as follows: '
-                            '{}'.format(r.json()))
-        session_id = r.json()['result']['sessionId']
-        self.headers['Authorization'] = session_id
+        for i in range(1, 10):
+            r = self.make_request(
+                self.login_url, method='POST', data=json.dumps(data),
+                headers=self.headers)
+            if 'result' in r.json() and 'sessionId' in r.json()['result']:
+                session_id = r.json()['result']['sessionId']
+                self.headers['Authorization'] = session_id
+                return True
+            else:
+                logging.warning('Could not set headers with error as follows, retrying:'
+                                '{}'.format(r.json()))
+        return False
 
     def make_request(self, url, method, headers=None, json_body=None, data=None,
                      attempt=1):
@@ -194,6 +198,10 @@ class SzkApi(object):
 
     def get_data(self, sd=None, ed=None, fields=None):
         fields = self.get_data_default_check(sd, ed, fields)
+        response = self.set_headers()
+        if not response:
+            logging.warning('Could not retrieve data. Returning empty dataframe')
+            return pd.DataFrame(data={})
         report_get_url = self.request_report(sd, ed, fields)
         report_dl_url = self.get_report_dl_url(report_get_url)
         self.df = self.download_report_to_df(report_dl_url)
@@ -201,7 +209,6 @@ class SzkApi(object):
 
     def request_report(self, sd, ed, fields):
         logging.info('Requesting report for {} to {}.'.format(sd, ed))
-        self.set_headers()
         report = self.create_report_body(fields)
         r = self.make_request(
             self.report_url, method='POST', headers=self.headers,


### PR DESCRIPTION
The original conditional if r.json['data'] would trigger the error that we are trying to avoid. Since we want to make sure 'data' key is in the r.json dictionary, in the case it is not in the dictionary indexing 'data' key would trigger an error.