### PR TITLE
attempt to add platform type to downloaded data

### DIFF
--- a/reporting/dcapi.py
+++ b/reporting/dcapi.py
@@ -19,8 +19,7 @@ base_url = 'https://www.googleapis.com/dfareporting'
 class DcApi(object):
     default_fields = [
         'campaign', 'campaignId', 'site', 'placement',
-        'date', 'placementId', 'creative', 'ad', 'creativeId', 'adId',
-        'PlatformType']
+        'date', 'placementId', 'creative', 'ad', 'creativeId', 'adId']
     default_metrics = [
         'impressions', 'clicks', 'clickRate',
         'activeViewViewableImpressions',
@@ -151,6 +150,8 @@ class DcApi(object):
             self.date_range = {'kind': 'dfareporting#dateRange',
                                'relativeDateRange': 'LAST_365_DAYS'}
             for field in fields:
+                if field == 'platformType':
+                    self.default_fields.append('platformType')
                 if field == '60':
                     self.date_range['relativeDateRange'] = 'LAST_60_DAYS'
                 elif field == '30':

--- a/reporting/dcapi.py
+++ b/reporting/dcapi.py
@@ -19,7 +19,8 @@ base_url = 'https://www.googleapis.com/dfareporting'
 class DcApi(object):
     default_fields = [
         'campaign', 'campaignId', 'site', 'placement',
-        'date', 'placementId', 'creative', 'ad', 'creativeId', 'adId']
+        'date', 'placementId', 'creative', 'ad', 'creativeId', 'adId',
+        'PlatformType']
     default_metrics = [
         'impressions', 'clicks', 'clickRate',
         'activeViewViewableImpressions',


### PR DESCRIPTION
the reason is that for our last campaign Nikki wanted more precise data than cross device, so we had to resort to using rawfiles, which add considerable amount of work. If we have this data easily available in our default rawfile, it would make it a lot easier to switch from current mpenvironment