### PR TITLE
Add plan net dict info to CheckAutoDictOrder in analyze.py and test in test_unit.py

### DIFF
--- a/reporting/analyze.py
+++ b/reporting/analyze.py
@@ -1063,6 +1063,7 @@ class CheckAutoDictOrder(AnalyzeBase):
 
     @staticmethod
     def get_vendor_list(col=dctc.VEN):
+        # Get from translational dictionary config
         tc = dct.DictTranslationConfig()
         tc.read(dctc.filename_tran_config)
         ven_list = []
@@ -1075,20 +1076,41 @@ class CheckAutoDictOrder(AnalyzeBase):
             ven_list = [x for x in ven_list if x not in ['nan', '0', 'None']]
         return ven_list
 
+    def get_plannet_vendor_list(self, ven_list=None, col=dctc.VEN):
+        # Get from plannet or add them to existing list
+        if ven_list is None:
+            ven_list = []
+        plannet_filename = self.matrix.vendor_set(vm.plan_key)[vmc.filename]
+        if os.path.isfile(plannet_filename):
+            pc = utl.import_read_csv(plannet_filename)
+            if col not in pc.columns:
+                return ven_list
+            new_ven_list = pc[col].unique().tolist()
+            ven_list = list(set(ven_list + new_ven_list))
+            ven_list = [x for x in ven_list if x not in ['nan', '0', 'None']]
+        return ven_list
+
     def do_analysis_on_data_source(self, source, df, ven_list=None,
-                                   cou_list=None):
+                                   cou_list=None, camp_list=None):
         if vmc.autodicord not in source.p:
             return df
         if not ven_list:
             ven_list = self.get_vendor_list()
+            ven_list = self.get_plannet_vendor_list(ven_list)
         if not cou_list:
             cou_list = self.get_vendor_list(dctc.COU)
-        auto_dict_idx = (source.p[vmc.autodicord].index(dctc.VEN)
-                         if dctc.VEN in source.p[vmc.autodicord] else None)
+            cou_list = self.get_plannet_vendor_list(cou_list, dctc.COU)
+        if not camp_list:
+            camp_list = self.get_vendor_list(dctc.CAM)
+            camp_list = self.get_plannet_vendor_list(camp_list, dctc.CAM)
+        ven_auto_dict_idx = (source.p[vmc.autodicord].index(dctc.VEN) if
+                             dctc.VEN in source.p[vmc.autodicord] else None)
+        camp_auto_dict_idx = (source.p[vmc.autodicord].index(dctc.CAM) if
+                              dctc.CAM in source.p[vmc.autodicord] else None)
         auto_order = source.p[vmc.autodicord]
-        if not auto_dict_idx or (len(auto_order) <= (auto_dict_idx + 1)):
+        if not ven_auto_dict_idx or (len(auto_order) <= (ven_auto_dict_idx + 1)):
             return df
-        cou_after_ven = auto_order[auto_dict_idx + 1] == dctc.COU
+        cou_after_ven = auto_order[ven_auto_dict_idx + 1] == dctc.COU
         if not cou_after_ven:
             return df
         tdf = source.get_raw_df()
@@ -1107,32 +1129,58 @@ class CheckAutoDictOrder(AnalyzeBase):
         max_idx = 0
         max_val = 0
         ven_counts = 0
+        camp_max_idx = 0
+        camp_max_val = 0
         for col in tdf.columns:
             cou_counts = tdf[col].isin(cou_list).sum()
+            camp_counts = tdf[col].isin(camp_list).sum()
             total = ven_counts + cou_counts
             if total > max_val:
                 max_val = total
                 max_idx = col - 1
+            if camp_counts > camp_max_val:
+                camp_max_val = camp_counts
+                camp_max_idx = col
             ven_counts = tdf[col].isin(ven_list).sum()
-        if auto_dict_idx and max_idx != auto_dict_idx and max_val > 0:
-            diff = auto_dict_idx - max_idx
-            if diff > 0:
-                new_order = auto_order[diff:]
-            else:
-                new_order = (diff * -1) * [dctc.MIS] + auto_order
-            data_dict = {vmc.vendorkey: source.key, self.name: new_order}
-            if df is None:
-                df = []
-            df.append(data_dict)
+        if camp_max_val > max_val:
+            # Shift order based on campaign name index
+            if (camp_auto_dict_idx and camp_max_idx != camp_auto_dict_idx and
+                    camp_max_val > 0):
+                diff = camp_auto_dict_idx - camp_max_idx
+                if diff > 0:
+                    new_order = auto_order[diff:]
+                else:
+                    new_order = (diff * -1) * [dctc.MIS] + auto_order
+                data_dict = {vmc.vendorkey: source.key, self.name: new_order}
+                if df is None:
+                    df = []
+                df.append(data_dict)
+        else:
+            if ven_auto_dict_idx and max_idx != ven_auto_dict_idx and max_val > 0:
+                # Shift order based on vendor name/country index
+                diff = ven_auto_dict_idx - max_idx
+                if diff > 0:
+                    new_order = auto_order[diff:]
+                else:
+                    new_order = (diff * -1) * [dctc.MIS] + auto_order
+                data_dict = {vmc.vendorkey: source.key, self.name: new_order}
+                if df is None:
+                    df = []
+                df.append(data_dict)
         return df
 
     def do_analysis(self):
         data_sources = self.matrix.get_all_data_sources()
         df = []
         ven_list = self.get_vendor_list()
+        ven_list = self.get_plannet_vendor_list(ven_list)
         cou_list = self.get_vendor_list(dctc.COU)
+        cou_list = self.get_plannet_vendor_list(cou_list, dctc.COU)
+        camp_list = self.get_vendor_list(dctc.CAM)
+        camp_list = self.get_plannet_vendor_list(camp_list, dctc.CAM)
         for ds in data_sources:
-            df = self.do_analysis_on_data_source(ds, df, ven_list, cou_list)
+            df = self.do_analysis_on_data_source(ds, df, ven_list, cou_list,
+                                                 camp_list)
         df = pd.DataFrame(df)
         if df.empty:
             msg = 'No new proposed order.'

--- a/reporting/analyze.py
+++ b/reporting/analyze.py
@@ -1063,7 +1063,8 @@ class CheckAutoDictOrder(AnalyzeBase):
 
     @staticmethod
     def get_vendor_list(col=dctc.VEN):
-        # Get from translational dictionary config
+        """ Returns list of unique items in mpVendor (or specified column) from
+                translational dictionary config. """
         tc = dct.DictTranslationConfig()
         tc.read(dctc.filename_tran_config)
         ven_list = []
@@ -1077,8 +1078,9 @@ class CheckAutoDictOrder(AnalyzeBase):
         return ven_list
 
     def get_plannet_vendor_list(self, ven_list=None, col=dctc.VEN):
-        # Get from plannet or add them to existing list
-        if ven_list is None:
+        """ Returns list of unique items in mpVendor (or specified column) from
+                plan net and items in ven_list if it is passed in. """
+        if not ven_list:
             ven_list = []
         plannet_filename = self.matrix.vendor_set(vm.plan_key)[vmc.filename]
         if os.path.isfile(plannet_filename):
@@ -1090,10 +1092,9 @@ class CheckAutoDictOrder(AnalyzeBase):
             ven_list = [x for x in ven_list if x not in ['nan', '0', 'None']]
         return ven_list
 
-    def do_analysis_on_data_source(self, source, df, ven_list=None,
-                                   cou_list=None, camp_list=None):
-        if vmc.autodicord not in source.p:
-            return df
+    def check_vendor_lists(self, ven_list=None, cou_list=None, camp_list=None):
+        """ Checks if vendor, country, and/or campaign lists are empty and
+        generates them if needed. Returns all three lists. """
         if not ven_list:
             ven_list = self.get_vendor_list()
             ven_list = self.get_plannet_vendor_list(ven_list)
@@ -1103,81 +1104,79 @@ class CheckAutoDictOrder(AnalyzeBase):
         if not camp_list:
             camp_list = self.get_vendor_list(dctc.CAM)
             camp_list = self.get_plannet_vendor_list(camp_list, dctc.CAM)
-        ven_auto_dict_idx = (source.p[vmc.autodicord].index(dctc.VEN) if
-                             dctc.VEN in source.p[vmc.autodicord] else None)
-        camp_auto_dict_idx = (source.p[vmc.autodicord].index(dctc.CAM) if
-                              dctc.CAM in source.p[vmc.autodicord] else None)
+        return ven_list, cou_list, camp_list
+
+    @staticmethod
+    def get_raw_data_vendor_idx(tdf, camp_ven_diff, ven_list, cou_list,
+                                  camp_list):
+        """ Determines the vendor index of a data source in the full placement
+        names by checking for vendor, country/region, and campaign items at
+        separation levels noted in the auto dictionary order. Returns the
+        index, or -1 if no item matches were found. """
+        max_idx, max_val = -1, 0
+        for col in tdf.columns:
+            ven_counts, cou_counts, camp_counts = 0, 0, 0
+            ven_counts = tdf[col].isin(ven_list).sum()
+            if col + 1 < len(tdf.columns):
+                cou_counts = tdf[col + 1].isin(cou_list).sum()
+            if 0 <= col + camp_ven_diff < len(tdf.columns):
+                camp_counts = tdf[col + camp_ven_diff].isin(camp_list).sum()
+            total = ven_counts + cou_counts + camp_counts
+            if total > max_val:
+                max_val = total
+                max_idx = col
+        return max_idx
+
+    def do_analysis_on_data_source(self, source, df, ven_list=None,
+                                   cou_list=None, camp_list=None):
+        """ Checks a data source's raw data placement against its auto
+        dictionary order from the vendormatrix. Suggests a shifted order if
+        they differ. """
+        if vmc.autodicord not in source.p:
+            return df
+        ven_list, cou_list, camp_list = (
+            self.check_vendor_lists(ven_list, cou_list, camp_list))
+        ven_auto_idx = (source.p[vmc.autodicord].index(dctc.VEN)
+                        if dctc.VEN in source.p[vmc.autodicord] else None)
+        camp_auto_idx = (source.p[vmc.autodicord].index(dctc.CAM)
+                             if dctc.CAM in source.p[vmc.autodicord]
+                         else ven_auto_idx)
         auto_order = source.p[vmc.autodicord]
-        if not ven_auto_dict_idx or (len(auto_order) <= (ven_auto_dict_idx + 1)):
+        if not ven_auto_idx or (len(auto_order) <= (ven_auto_idx + 1)):
             return df
-        cou_after_ven = auto_order[ven_auto_dict_idx + 1] == dctc.COU
-        if not cou_after_ven:
+        if not auto_order[ven_auto_idx + 1] == dctc.COU:
             return df
+        camp_shift = camp_auto_idx - ven_auto_idx
         tdf = source.get_raw_df()
-        if dctc.FPN not in tdf.columns or tdf.empty:
-            return df
         auto_place = source.p[vmc.autodicplace]
         if auto_place == dctc.PN:
             auto_place = source.p[vmc.placement]
-        if auto_place not in tdf.columns:
+        if (dctc.FPN not in tdf.columns or tdf.empty
+                or auto_place not in tdf.columns):
             return df
         if tdf[auto_place].isnull().values.any():
             msg = 'contains NaN, suggest choosing different placement column'
             logging.warning('{} {}]'.format(auto_place, msg))
             tdf[auto_place] = tdf[auto_place].astype(str)
         tdf = pd.DataFrame(tdf[auto_place].str.split('_').to_list())
-        max_idx = 0
-        max_val = 0
-        ven_counts = 0
-        camp_max_idx = 0
-        camp_max_val = 0
-        for col in tdf.columns:
-            cou_counts = tdf[col].isin(cou_list).sum()
-            camp_counts = tdf[col].isin(camp_list).sum()
-            total = ven_counts + cou_counts
-            if total > max_val:
-                max_val = total
-                max_idx = col - 1
-            if camp_counts > camp_max_val:
-                camp_max_val = camp_counts
-                camp_max_idx = col
-            ven_counts = tdf[col].isin(ven_list).sum()
-        if camp_max_val > max_val:
-            # Shift order based on campaign name index
-            if (camp_auto_dict_idx and camp_max_idx != camp_auto_dict_idx and
-                    camp_max_val > 0):
-                diff = camp_auto_dict_idx - camp_max_idx
-                if diff > 0:
-                    new_order = auto_order[diff:]
-                else:
-                    new_order = (diff * -1) * [dctc.MIS] + auto_order
-                data_dict = {vmc.vendorkey: source.key, self.name: new_order}
-                if df is None:
-                    df = []
-                df.append(data_dict)
-        else:
-            if ven_auto_dict_idx and max_idx != ven_auto_dict_idx and max_val > 0:
-                # Shift order based on vendor name/country index
-                diff = ven_auto_dict_idx - max_idx
-                if diff > 0:
-                    new_order = auto_order[diff:]
-                else:
-                    new_order = (diff * -1) * [dctc.MIS] + auto_order
-                data_dict = {vmc.vendorkey: source.key, self.name: new_order}
-                if df is None:
-                    df = []
-                df.append(data_dict)
+        ven_raw_idx = self.get_raw_data_vendor_idx(tdf, camp_shift, ven_list,
+                                                   cou_list, camp_list)
+        if 0 <= ven_raw_idx != ven_auto_idx:
+            diff = ven_auto_idx - ven_raw_idx
+            if diff > 0:
+                new_order = auto_order[diff:]
+            else:
+                new_order = (diff * -1) * [dctc.MIS] + auto_order
+            data_dict = {vmc.vendorkey: source.key, self.name: new_order}
+            if not df:
+                df = []
+            df.append(data_dict)
         return df
 
     def do_analysis(self):
         data_sources = self.matrix.get_all_data_sources()
         df = []
-        ven_list = self.get_vendor_list()
-        ven_list = self.get_plannet_vendor_list(ven_list)
-        cou_list = self.get_vendor_list(dctc.COU)
-        cou_list = self.get_plannet_vendor_list(cou_list, dctc.COU)
-        camp_list = self.get_vendor_list(dctc.CAM)
-        camp_list = self.get_plannet_vendor_list(camp_list, dctc.CAM)
+        ven_list, cou_list, camp_list = self.check_vendor_lists()
         for ds in data_sources:
             df = self.do_analysis_on_data_source(ds, df, ven_list, cou_list,
                                                  camp_list)

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -587,6 +587,101 @@ class TestAnalyze:
         self.vm_df = vm_df
         return vm_df
 
+    @pytest.fixture
+    def test_vm2(self):
+        vm_dict = {
+            'Vendor Key':
+                {0: 'API_Meta_Test', 1: 'API_Youtube_Test',
+                 2: 'API_Rawfile_Test', 3: 'Plan Net'},
+            'FILENAME': {0: 'meta_test.csv', 1: 'youtube_test.csv',
+                         2: 'rawfile_test.csv', 3: 'plannet_test.csv'},
+            'FIRSTROW': {0: 0, 1: 0, 2: 0, 3: 0},
+            'LASTROW': {0: 0, 1: 0, 2: 0, 3: 0},
+            'Full Placement Name': {
+                0: '::Campaign Name|Ad Set Name|Ad Name',
+                1: '::Campaign|Ad group|Ad',
+                2: 'Placement Name',
+                3: 'mpCampaign|mpVendor'},
+            'Placement Name': {0: 'Ad Name', 1: 'Ad', 2: 'Placement Name',
+                               3: 'mpVendor'},
+            'FILENAME_DICTIONARY': {0: 'meta_dictionary_test.csv',
+                                    1: 'youtube_dictionary_test.csv',
+                                    2: 'rawfile_dictionary_test.csv',
+                                    3: 'plannet_dictionary.csv'},
+            'FILENAME_ERROR': {0: 'FACEBOOK_ERROR_REPORT.csv',
+                               1: 'YOUTUBE_ERROR_REPORT.csv',
+                               2: 'RAWFILE_ERROR_REPORT.csv',
+                               3: 'PLANNET_ERROR_REPORT.csv'},
+            'START DATE': {0: '10/7/2024', 1: '10/7/2024',
+                           2: '10/10/2024', 3: ''},
+            'END DATE': {0: '', 1: '', 2: '', 3: ''},
+            'DROP_COLUMNS': {0: 'ALL', 1: 'ALL', 2: 'ALL', 3: 'ALL'},
+            'AUTO DICTIONARY PLACEMENT': {0: 'Full Placement Name',
+                                          1: 'Full Placement Name',
+                                          2: 'Full Placement Name',
+                                          3: 'Full Placement Name'},
+            'AUTO DICTIONARY ORDER': {
+                0: 'mpBudget|mpVendor|mpCountry/Region|mpCampaign',
+                1: 'mpMisc|mpBudget|mpVendor|mpCountry/Region|mpCampaign',
+                2: 'mpMisc|mpBudget|mpVendor|mpCountry/Region|mpCampaign',
+                3: ''},
+            'API_FILE': {0: 'fbconfig_meta_test.json',
+                         1: 'awconfig_yt_test.yaml',
+                         2: 'rawfileapi_test.json', 3: ''},
+            'API_FIELDS': {0: 'Actions', 1: '', 2: '', 3: ''},
+            'API_MERGE': {0: '', 1: '', 2: '', 3: ''},
+            'TRANSFORM': {0: '', 1: '', 2: '', 3: ''},
+            'HEADER': {0: '', 1: '', 2: '', 3: ''},
+            'OMIT_PLAN': {0: '', 1: '', 2: '', 3: ''},
+            'Date': {0: 'Reporting Starts', 1: 'Day', 2: 'Day', 3: ''},
+            'Impressions': {0: 'Impressions', 1: 'Impressions',
+                            2: 'Impressions', 3: ''},
+            'Clicks': {0: 'Link Clicks', 1: 'Clicks', 2: 'Clicks', 3: ''},
+            'Net Cost': {0: 'Amount Spent (USD)', 1: 'Cost', 2: 'Cost',
+                         3: ''},
+            'Video Views': {0: '10-Second Video Views', 1: 'Views',
+                            2: 'Video Starts', 3: ''},
+            'Video Views 25': {0: 'Video Watches at 25%',
+                               1: 'Video played to 25%',
+                               2: 'Video View 25%', 3: ''},
+            'Video Views 50': {0: 'Video Watches at 50%',
+                               1: 'Video played to 50%',
+                               2: 'Video View 50%', 3: ''},
+            'Video Views 75': {0: 'Video Watches at 75%',
+                               1: 'Video played to 75%',
+                               2: 'Video View 75%', 3: ''},
+            'Video Views 100': {0: 'Video Watches at 100%',
+                                1: 'Video played to 100%',
+                                2: 'Video View 100%', 3: ''},
+            'RULE_1_FACTOR': {0: '', 1: '', 2: '', 3: ''},
+            'RULE_1_METRIC': {0: '', 1: '', 2: '', 3: ''},
+            'RULE_1_QUERY': {0: '', 1: '', 2: '', 3: ''},
+            'RULE_2_FACTOR': {0: 0.0, 1: 0.0, 2: '', 3: 0.0},
+            'RULE_2_METRIC': {0: 'POST::Adserving Cost',
+                              1: 'POST::Adserving Cost', 2: '',
+                              3: 'POST::Adserving Cost'},
+            'RULE_2_QUERY': {0: 'mpAgency::Liquid Advertising',
+                             1: 'mpAgency::Liquid Advertising', 2: '',
+                             3: 'mpAgency::Liquid Advertising'},
+            'RULE_3_FACTOR': {0: 0.1, 1: '', 2: '', 3: ''},
+            'RULE_3_METRIC': {0: '', 1: '', 2: '', 3: ''},
+            'RULE_3_QUERY': {0: '', 1: '', 2: '', 3: ''},
+            'RULE_4_FACTOR': {0: '', 1: '', 2: '', 3: ''},
+            'RULE_4_METRIC': {0: '', 1: '', 2: '', 3: ''},
+            'RULE_4_QUERY': {0: '', 1: '', 2: '', 3: ''},
+            'RULE_5_FACTOR': {0: '', 1: '', 2: '', 3: ''},
+            'RULE_5_METRIC': {0: '', 1: '', 2: '', 3: ''},
+            'RULE_5_QUERY': {0: '', 1: '', 2: '', 3: ''},
+            'RULE_6_FACTOR': {0: '', 1: '', 2: '', 3: ''},
+            'RULE_6_METRIC': {0: '', 1: '', 2: '', 3: ''},
+            'RULE_6_QUERY': {0: '', 1: '', 2: '', 3: ''}
+        }
+        for key in vmc.datacol:
+            if key not in vm_dict:
+                vm_dict[key] = {0: '', 1: '', 2: ''}
+        vm_df = pd.DataFrame(vm_dict)
+        return vm_df
+
     def test_double_fix_all_raw(self, test_vm):
         """
         If test is failing due to Vendor Key errors, ensure 'Vendormatrix.csv'
@@ -814,6 +909,100 @@ class TestAnalyze:
         assert not df.empty
         assert df.equals(match_df)
         """
+
+    @pytest.fixture
+    def setup_autodict_files(self, test_vm2):
+        """ Creates meta_test.csv, youtube_test.csv, rawfile_test.csv,
+        and plannet_test.csv in raw_data and populates them with data for
+        test_autodict_analysis. """
+        meta_data = {
+            'Campaign Name':
+                {0: 'SegaMeta', 1: 'SegaMeta'},
+            'Ad Set Name':
+                {0: 'Set 1', 1: 'Set 2'},
+            'Ad Name':
+                {0: '01234567_YouTube_US_Pre-Launch',
+                 1: '01234567_YouTube_US_Post-Launch'}
+        }
+        yt_data = {
+            'Campaign':
+                {0: 'SegaYT', 1: 'SegaYT', 2: 'SegaYT'},
+            'Ad group':
+                {0: 'Group 1', 1: 'Group 2', 2: 'Group 3'},
+            'Ad':
+                {0: '01234567_You tube_MX_Pre-Launch',
+                 1: '01234567_You tube_BR_Pre-Order',
+                 2: '01234567_You tube_MX_Post-Launch'}
+        }
+        raw_data = {
+            'Placement Name':
+                {0: '01234567_PlayStation_GB_Pre-Order',
+                 1: '01234567_PlayStation_MX_Pre-Launch'}
+        }
+        plannet_data = {
+            'mpCampaign':
+                {0: 'Pre-Launch', 1: 'Pre-Launch', 2: 'Pre-Order',
+                 3: 'Pre-Order', 4: 'Post-Launch', 5: 'Post-Launch',
+                 6: 'Pre-Launch'},
+            'mpVendor':
+                {0: 'Meta', 1: 'YouTube', 2: 'PlayStation', 3: 'YouTube',
+                 4: 'YouTube', 5: 'Meta', 6: 'PlayStation'},
+            'Planned Net Cost':
+                {0: 6000, 1: 5000, 2: 7000, 3: 5000, 4: 4000, 5: 8000, 6: 6000},
+            'Full Placement Name':
+                {0: 'Pre-Launch_Meta_US', 1: 'Pre-Launch_YouTube_MX',
+                 2: 'Pre-Order_PlayStation_GB', 3: 'Pre-Order_YouTube_BR',
+                 4: 'Post-Launch_YouTube_MX', 5: 'Post-Launch_Meta_US',
+                 6: 'Pre-Launch_PlayStation_MX'},
+            'Uncapped':
+                {0: 'TRUE', 1: 'TRUE', 2: 'FALSE', 3: 'TRUE', 4: 'TRUE',
+                 5: 'TRUE', 6: 'FALSE'},
+            'index': {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6},
+        }
+        files_to_write = {
+            test_vm2[vmc.filename][0]: pd.DataFrame(meta_data),
+            test_vm2[vmc.filename][1]: pd.DataFrame(yt_data),
+            test_vm2[vmc.filename][2]: pd.DataFrame(raw_data),
+            test_vm2[vmc.filename][3]: pd.DataFrame(plannet_data)
+        }
+        for filename in files_to_write:
+            files_to_write[filename].to_csv('raw_data/{}'.format(filename),
+                                            index=False)
+        return test_vm2
+
+    def test_autodict_analysis(self, setup_autodict_files):
+        """
+        Tests CheckAutoDictOrder using auto dict order/data source
+        combinations that should result in a positive shift via Vendor
+        position (Meta test), a positive shift via Campaign position (Youtube
+        test), and a negative shift via Vendor position (Rawfile test) for
+        the suggested orders.
+        'positive shift' = suggests shifting order to the right by appending
+        'mpMisc' cells to the start of the list
+        'negative shift' = suggests shifting order cell to the left by removing
+        cells from the start of the list
+        """
+        vm_dict = setup_autodict_files
+        matrix = vm.VendorMatrix()
+        matrix.vm_parse(vm_dict)
+        aly = az.Analyze(df=pd.DataFrame(), matrix=matrix)
+        aly.do_all_analysis()
+        suggested_orders = aly.analysis_dict[11]['data']
+        expected_orders = {
+            vm_dict[vmc.vendorkey][0]:
+                ('mpMisc|mpMisc|' + vm_dict[vmc.autodicord][0]).split('|'),
+            vm_dict[vmc.vendorkey][1]:
+                ('mpMisc|' + vm_dict[vmc.autodicord][1]).split('|'),
+            vm_dict[vmc.vendorkey][2]:
+                vm_dict[vmc.autodicord][2].split('|')[1::]
+        }
+        assert len(expected_orders) == len(suggested_orders[vmc.vendorkey])
+        for index in suggested_orders[vmc.vendorkey]:
+            expected = expected_orders[suggested_orders[vmc.vendorkey][index]]
+            suggested = suggested_orders['change_auto_order'][index]
+            assert expected == suggested
+        for file in vm_dict[vmc.filename]:
+            os.remove('raw_data/{}'.format(file))
 
     def test_all_analysis_on_empty_df(self):
         aly = az.Analyze(df=pd.DataFrame(), matrix=vm.VendorMatrix())

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -929,7 +929,10 @@ class TestAnalyze:
         matrix.vm_parse(vm_dict)
         aly = az.Analyze(df=pd.DataFrame(), matrix=matrix)
         aly.do_all_analysis()
-        suggested_orders = aly.analysis_dict[11]['data']
+        i = 0
+        while aly.analysis_dict[i]['key'] != 'change_auto_order':
+            i += 1
+        suggested_orders = aly.analysis_dict[i]['data']
         expected_orders = {
             vm_dict[vmc.vendorkey][0]:
                 ('mpMisc|mpMisc|' + vm_dict[vmc.autodicord][0]).split('|'),

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -591,10 +591,10 @@ class TestAnalyze:
     def test_vm2(self):
         vm_dict = {
             'Vendor Key':
-                {0: 'API_Meta_Test', 1: 'API_Youtube_Test',
-                 2: 'API_Rawfile_Test', 3: 'Plan Net'},
-            'FILENAME': {0: 'meta_test.csv', 1: 'youtube_test.csv',
-                         2: 'rawfile_test.csv', 3: 'plannet_test.csv'},
+                {0: 'API_Ven1_Test', 1: 'API_Ven2_Test',
+                 2: 'API_Ven3_Test', 3: 'Plan Net'},
+            'FILENAME': {0: 'ven1_test.csv', 1: 'ven2_test.csv',
+                         2: 'ven3_test.csv', 3: 'plannet_test.csv'},
             'FIRSTROW': {0: 0, 1: 0, 2: 0, 3: 0},
             'LASTROW': {0: 0, 1: 0, 2: 0, 3: 0},
             'Full Placement Name': {
@@ -604,13 +604,13 @@ class TestAnalyze:
                 3: 'mpCampaign|mpVendor'},
             'Placement Name': {0: 'Ad Name', 1: 'Ad', 2: 'Placement Name',
                                3: 'mpVendor'},
-            'FILENAME_DICTIONARY': {0: 'meta_dictionary_test.csv',
-                                    1: 'youtube_dictionary_test.csv',
-                                    2: 'rawfile_dictionary_test.csv',
+            'FILENAME_DICTIONARY': {0: 'ven1_dictionary_test.csv',
+                                    1: 'ven2_dictionary_test.csv',
+                                    2: 'ven3_dictionary_test.csv',
                                     3: 'plannet_dictionary.csv'},
-            'FILENAME_ERROR': {0: 'FACEBOOK_ERROR_REPORT.csv',
-                               1: 'YOUTUBE_ERROR_REPORT.csv',
-                               2: 'RAWFILE_ERROR_REPORT.csv',
+            'FILENAME_ERROR': {0: 'VEN1_ERROR_REPORT.csv',
+                               1: 'VEN2_ERROR_REPORT.csv',
+                               2: 'VEN3_ERROR_REPORT.csv',
                                3: 'PLANNET_ERROR_REPORT.csv'},
             'START DATE': {0: '10/7/2024', 1: '10/7/2024',
                            2: '10/10/2024', 3: ''},
@@ -625,60 +625,13 @@ class TestAnalyze:
                 1: 'mpMisc|mpBudget|mpVendor|mpCountry/Region|mpCampaign',
                 2: 'mpMisc|mpBudget|mpVendor|mpCountry/Region|mpCampaign',
                 3: ''},
-            'API_FILE': {0: 'fbconfig_meta_test.json',
-                         1: 'awconfig_yt_test.yaml',
-                         2: 'rawfileapi_test.json', 3: ''},
-            'API_FIELDS': {0: 'Actions', 1: '', 2: '', 3: ''},
-            'API_MERGE': {0: '', 1: '', 2: '', 3: ''},
-            'TRANSFORM': {0: '', 1: '', 2: '', 3: ''},
-            'HEADER': {0: '', 1: '', 2: '', 3: ''},
-            'OMIT_PLAN': {0: '', 1: '', 2: '', 3: ''},
-            'Date': {0: 'Reporting Starts', 1: 'Day', 2: 'Day', 3: ''},
-            'Impressions': {0: 'Impressions', 1: 'Impressions',
-                            2: 'Impressions', 3: ''},
-            'Clicks': {0: 'Link Clicks', 1: 'Clicks', 2: 'Clicks', 3: ''},
-            'Net Cost': {0: 'Amount Spent (USD)', 1: 'Cost', 2: 'Cost',
-                         3: ''},
-            'Video Views': {0: '10-Second Video Views', 1: 'Views',
-                            2: 'Video Starts', 3: ''},
-            'Video Views 25': {0: 'Video Watches at 25%',
-                               1: 'Video played to 25%',
-                               2: 'Video View 25%', 3: ''},
-            'Video Views 50': {0: 'Video Watches at 50%',
-                               1: 'Video played to 50%',
-                               2: 'Video View 50%', 3: ''},
-            'Video Views 75': {0: 'Video Watches at 75%',
-                               1: 'Video played to 75%',
-                               2: 'Video View 75%', 3: ''},
-            'Video Views 100': {0: 'Video Watches at 100%',
-                                1: 'Video played to 100%',
-                                2: 'Video View 100%', 3: ''},
-            'RULE_1_FACTOR': {0: '', 1: '', 2: '', 3: ''},
-            'RULE_1_METRIC': {0: '', 1: '', 2: '', 3: ''},
-            'RULE_1_QUERY': {0: '', 1: '', 2: '', 3: ''},
-            'RULE_2_FACTOR': {0: 0.0, 1: 0.0, 2: '', 3: 0.0},
-            'RULE_2_METRIC': {0: 'POST::Adserving Cost',
-                              1: 'POST::Adserving Cost', 2: '',
-                              3: 'POST::Adserving Cost'},
-            'RULE_2_QUERY': {0: 'mpAgency::Liquid Advertising',
-                             1: 'mpAgency::Liquid Advertising', 2: '',
-                             3: 'mpAgency::Liquid Advertising'},
-            'RULE_3_FACTOR': {0: 0.1, 1: '', 2: '', 3: ''},
-            'RULE_3_METRIC': {0: '', 1: '', 2: '', 3: ''},
-            'RULE_3_QUERY': {0: '', 1: '', 2: '', 3: ''},
-            'RULE_4_FACTOR': {0: '', 1: '', 2: '', 3: ''},
-            'RULE_4_METRIC': {0: '', 1: '', 2: '', 3: ''},
-            'RULE_4_QUERY': {0: '', 1: '', 2: '', 3: ''},
-            'RULE_5_FACTOR': {0: '', 1: '', 2: '', 3: ''},
-            'RULE_5_METRIC': {0: '', 1: '', 2: '', 3: ''},
-            'RULE_5_QUERY': {0: '', 1: '', 2: '', 3: ''},
-            'RULE_6_FACTOR': {0: '', 1: '', 2: '', 3: ''},
-            'RULE_6_METRIC': {0: '', 1: '', 2: '', 3: ''},
-            'RULE_6_QUERY': {0: '', 1: '', 2: '', 3: ''}
+            'API_FILE': {0: 'ven1_config_test.json',
+                         1: 'ven2_config_test.yaml',
+                         2: 'ven3_config_test.json', 3: ''}
         }
-        for key in vmc.datacol:
+        for key in vmc.datacol + vmc.vmkeys:
             if key not in vm_dict:
-                vm_dict[key] = {0: '', 1: '', 2: ''}
+                vm_dict[key] = {0: '', 1: '', 2: '', 3: ''}
         vm_df = pd.DataFrame(vm_dict)
         return vm_df
 
@@ -912,32 +865,32 @@ class TestAnalyze:
 
     @pytest.fixture
     def setup_autodict_files(self, test_vm2):
-        """ Creates meta_test.csv, youtube_test.csv, rawfile_test.csv,
-        and plannet_test.csv in raw_data and populates them with data for
-        test_autodict_analysis. """
-        meta_data = {
+        """ Creates ven1_test.csv,ven2_test.csv, ven3_test.csv, and
+        plannet_test.csv in the raw_data folder and populates them with data
+        that should trigger new order suggestions for test_autodict_analysis. """
+        data1 = {
             'Campaign Name':
-                {0: 'SegaMeta', 1: 'SegaMeta'},
+                {0: 'Campaign 1', 1: 'Campaign 2'},
             'Ad Set Name':
                 {0: 'Set 1', 1: 'Set 2'},
             'Ad Name':
-                {0: '01234567_YouTube_US_Pre-Launch',
-                 1: '01234567_YouTube_US_Post-Launch'}
+                {0: '01234567_Vendor1_US_Pre-Launch',
+                 1: '01234567_Vendor1_US_Post-Launch'}
         }
-        yt_data = {
+        data2 = {
             'Campaign':
-                {0: 'SegaYT', 1: 'SegaYT', 2: 'SegaYT'},
+                {0: 'Campaign 1', 1: 'Campaign 2', 2: 'Campaign 3'},
             'Ad group':
                 {0: 'Group 1', 1: 'Group 2', 2: 'Group 3'},
             'Ad':
-                {0: '01234567_You tube_MX_Pre-Launch',
-                 1: '01234567_You tube_BR_Pre-Order',
-                 2: '01234567_You tube_MX_Post-Launch'}
+                {0: '01234567_Vendor 2_MX_Pre-Launch',
+                 1: '01234567_Vendor 2_BR_Pre-Order',
+                 2: '01234567_Vendor 2_MX_Post-Launch'}
         }
-        raw_data = {
+        data3 = {
             'Placement Name':
-                {0: '01234567_PlayStation_GB_Pre-Order',
-                 1: '01234567_PlayStation_MX_Pre-Launch'}
+                {0: '01234567_Vendor3_GB_Pre-Order',
+                 1: '01234567_Vendor3_MX_Pre-Launch'}
         }
         plannet_data = {
             'mpCampaign':
@@ -945,24 +898,13 @@ class TestAnalyze:
                  3: 'Pre-Order', 4: 'Post-Launch', 5: 'Post-Launch',
                  6: 'Pre-Launch'},
             'mpVendor':
-                {0: 'Meta', 1: 'YouTube', 2: 'PlayStation', 3: 'YouTube',
-                 4: 'YouTube', 5: 'Meta', 6: 'PlayStation'},
-            'Planned Net Cost':
-                {0: 6000, 1: 5000, 2: 7000, 3: 5000, 4: 4000, 5: 8000, 6: 6000},
-            'Full Placement Name':
-                {0: 'Pre-Launch_Meta_US', 1: 'Pre-Launch_YouTube_MX',
-                 2: 'Pre-Order_PlayStation_GB', 3: 'Pre-Order_YouTube_BR',
-                 4: 'Post-Launch_YouTube_MX', 5: 'Post-Launch_Meta_US',
-                 6: 'Pre-Launch_PlayStation_MX'},
-            'Uncapped':
-                {0: 'TRUE', 1: 'TRUE', 2: 'FALSE', 3: 'TRUE', 4: 'TRUE',
-                 5: 'TRUE', 6: 'FALSE'},
-            'index': {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6},
+                {0: 'Vendor1', 1: 'Vendor2', 2: 'Vendor3', 3: 'Vendor2',
+                 4: 'Vendor2', 5: 'Vendor1', 6: 'Vendor3'},
         }
         files_to_write = {
-            test_vm2[vmc.filename][0]: pd.DataFrame(meta_data),
-            test_vm2[vmc.filename][1]: pd.DataFrame(yt_data),
-            test_vm2[vmc.filename][2]: pd.DataFrame(raw_data),
+            test_vm2[vmc.filename][0]: pd.DataFrame(data1),
+            test_vm2[vmc.filename][1]: pd.DataFrame(data2),
+            test_vm2[vmc.filename][2]: pd.DataFrame(data3),
             test_vm2[vmc.filename][3]: pd.DataFrame(plannet_data)
         }
         for filename in files_to_write:
@@ -974,9 +916,9 @@ class TestAnalyze:
         """
         Tests CheckAutoDictOrder using auto dict order/data source
         combinations that should result in a positive shift via Vendor
-        position (Meta test), a positive shift via Campaign position (Youtube
-        test), and a negative shift via Vendor position (Rawfile test) for
-        the suggested orders.
+        position (Ven1 test), a positive shift via Campaign position (Ven2
+        test), and a negative shift via Vendor position (Ven3 test) for the
+        suggested orders.
         'positive shift' = suggests shifting order to the right by appending
         'mpMisc' cells to the start of the list
         'negative shift' = suggests shifting order cell to the left by removing

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -431,6 +431,30 @@ class TestCalc:
 
 class TestAnalyze:
     vm_df = None
+    
+    @staticmethod
+    def get_rule_names():
+        names = []
+        for x in range(1, 7):
+            for y in utl.RULE_CONST:
+                names.append('RULE_{}_{}'.format(x, y))
+        return names
+
+    def generate_test_vm(self, data_dict, num_rows):
+        vm_dict = {}
+        vm_keys = [vmc.vendorkey] + vmc.vmkeys + self.get_rule_names()
+        for key in vm_keys:
+            if key in data_dict:
+                vm_dict[key] = data_dict[key]
+            else:
+                val = ''
+                if key is vmc.firstrow or key is vmc.lastrow:
+                    val = 0
+                elif key is vmc.autodicplace:
+                    val = vmc.fullplacename
+                vm_dict[key] = {i: val for i in range(num_rows)}
+        vm_df = pd.DataFrame(vm_dict)
+        return vm_df
 
     def test_check_flat(self):
         df = pd.DataFrame({
@@ -499,59 +523,41 @@ class TestAnalyze:
     @pytest.fixture
     def test_vm(self):
         vm_dict = {
-            'Vendor Key':
+            vmc.vendorkey:
                 {0: 'API_DCM_Test', 1: 'API_Tiktok_Test',
                  2: 'API_Rawfile_Test', 3: 'Plan Net'},
-            'FILENAME': {0: 'dcm_Test', 1: 'tiktok_Test.csv',
-                         2: 'Rawfile_Test.csv', 3: 'plannet.csv'},
-            'FIRSTROW': {0: 0, 1: 0, 2: 0, 3: 0},
-            'LASTROW': {0: 0, 1: 0, 2: 0, 3: 0},
-            'Full Placement Name': {0: 'Placement', 1: 'ad_name',
-                                    2: 'ad_name', 3: 'mpCampaign|mpVendor'},
-            'Placement Name': {0: 'Placement', 1: 'ad_name',
-                               2: 'ad_name', 3: 'mpVendor'},
-            'FILENAME_DICTIONARY': {0: 'dcm_dictionary_Test',
-                                    1: 'tiktok_dictionary_Test.csv',
-                                    2: 'Rawfile_dictionary_Test.csv',
-                                    3: 'plannet_dictionary.csv'},
-            'FILENAME_ERROR': {0: 'DCM_ERROR_REPORT.csv',
-                               1: 'TIKTOK_ERROR_REPORT.csv',
-                               2: 'Rawfile_ERROR_REPORT.csv',
-                               3: 'PLANNET_ERROR_REPORT.csv'},
-            'START DATE': {0: '7/18/2022', 1: '7/1/2022',
+            vmc.filename: {0: 'dcm_Test', 1: 'tiktok_Test.csv',
+                           2: 'Rawfile_Test.csv', 3: 'plannet.csv'},
+            vmc.fullplacename: {0: 'Placement', 1: 'ad_name',
+                                2: 'ad_name', 3: 'mpCampaign|mpVendor'},
+            vmc.placement: {0: 'Placement', 1: 'ad_name',
+                            2: 'ad_name', 3: 'mpVendor'},
+            vmc.startdate: {0: '7/18/2022', 1: '7/1/2022',
                            2: '7/1/2022', 3: ''},
-            'END DATE': {0: '', 1: '7/27/2022', 2: '7/27/2022', 3: ''},
-            'DROP_COLUMNS': {0: 'ALL', 1: 'ALL', 2: 'ALL', 3: ''},
-            'AUTO DICTIONARY PLACEMENT': {0: 'Full Placement Name',
-                                          1: 'Full Placement Name',
-                                          2: 'Full Placement Name',
-                                          3: 'Full Placement Name'},
-            'AUTO DICTIONARY ORDER': {
+            vmc.enddate: {0: '', 1: '7/27/2022', 2: '7/27/2022', 3: ''},
+            vmc.dropcol: {0: 'ALL', 1: 'ALL', 2: 'ALL', 3: ''},
+            vmc.autodicord: {
                 0: 'mpCampaign|mpVendor', 1: 'mpCampaign|mpVendor',
                 2: 'mpCampaign|mpVendor', 3: 'mpCampaign|mpVendor'},
-            'API_FILE': {0: 'dcapi_Test.json', 1: 'tikapi_Test.json',
-                         2: 'tikapi_Test.json', 3: ''},
-            'API_FIELDS': {0: '', 1: '', 2: '', 3: ''},
-            'API_MERGE': {0: '', 1: '', 2: '', 3: ''},
-            'TRANSFORM': {0: '', 1: '', 2: '', 3: ''},
-            'HEADER': {0: '', 1: '', 2: '', 3: ''},
-            'OMIT_PLAN': {0: '', 1: '', 2: '', 3: ''},
-            'Date': {0: 'Date', 1: 'stat_datetime', 2: 'stat_datetime', 3: ''},
-            'Impressions': {0: 'Impressions', 1: 'show_cnt',
+            vmc.apifile: {0: 'dcapi_Test.json', 1: 'tikapi_Test.json',
+                          2: 'tikapi_Test.json', 3: ''},
+            vmc.date: {0: 'Date', 1: 'stat_datetime',
+                             2: 'stat_datetime', 3: ''},
+            vmc.impressions: {0: 'Impressions', 1: 'show_cnt',
                             2: 'show_cnt', 3: ''},
-            'Clicks': {0: 'Clicks', 1: 'click_cnt', 2: 'click_cnt', 3: ''},
-            'Net Cost': {0: '', 1: 'stat_cost', 2: 'stat_cost', 3: ''},
-            'Video Views': {0: 'TrueView Views', 1: 'total_play',
+            vmc.clicks: {0: 'Clicks', 1: 'click_cnt', 2: 'click_cnt', 3: ''},
+            vmc.cost: {0: '', 1: 'stat_cost', 2: 'stat_cost', 3: ''},
+            vmc.views: {0: 'TrueView Views', 1: 'total_play',
                             2: 'total_play', 3: ''},
-            'Video Views 25': {0: 'Video First Quartile Completions',
+            vmc.views25: {0: 'Video First Quartile Completions',
                                1: 'play_first_quartile',
                                2: 'play_first_quartile', 3: ''},
-            'Video Views 50': {0: 'Video Midpoints', 1: 'play_midpoint',
+            vmc.views50: {0: 'Video Midpoints', 1: 'play_midpoint',
                                2: 'play_midpoint', 3: ''},
-            'Video Views 75': {0: 'Video Third Quartile Completions',
+            vmc.views75: {0: 'Video Third Quartile Completions',
                                1: 'play_third_quartile',
                                2: 'play_third_quartile', 3: ''},
-            'Video Views 100': {0: 'Video Completions', 1: 'play_over',
+            vmc.views100: {0: 'Video Completions', 1: 'play_over',
                                 2: 'play_over', 3: ''},
             'RULE_1_METRIC': {0: 'POST::Impressions|Clicks', 1: '',
                               2: '', 3: ''},
@@ -569,72 +575,12 @@ class TestAnalyze:
             'RULE_3_METRIC': {0: 'POST::Adserving Cost::DCM Service Fee',
                               1: '', 2: '', 3: ''},
             'RULE_3_QUERY': {0: 'mpAgency::Liquid Advertising',
-                             1: '', 2: '', 3: ''},
-            'RULE_4_FACTOR': {0: '', 1: '', 2: '', 3: ''},
-            'RULE_4_METRIC': {0: '', 1: '', 2: '', 3: ''},
-            'RULE_4_QUERY': {0: '', 1: '', 2: '', 3: ''},
-            'RULE_5_FACTOR': {0: '', 1: '', 2: '', 3: ''},
-            'RULE_5_METRIC': {0: '', 1: '', 2: '', 3: ''},
-            'RULE_5_QUERY': {0: '', 1: '', 2: '', 3: ''},
-            'RULE_6_FACTOR': {0: '', 1: '', 2: '', 3: ''},
-            'RULE_6_METRIC': {0: '', 1: '', 2: '', 3: ''},
-            'RULE_6_QUERY': {0: '', 1: '', 2: '', 3: ''}
+                             1: '', 2: '', 3: ''}
         }
-        for key in vmc.datacol:
-            if key not in vm_dict:
-                vm_dict[key] = {0: '', 1: '', 2: ''}
-        vm_df = pd.DataFrame(vm_dict)
-        self.vm_df = vm_df
-        return vm_df
 
-    @pytest.fixture
-    def test_vm2(self):
-        vm_dict = {
-            'Vendor Key':
-                {0: 'API_Ven1_Test', 1: 'API_Ven2_Test',
-                 2: 'API_Ven3_Test', 3: 'Plan Net'},
-            'FILENAME': {0: 'ven1_test.csv', 1: 'ven2_test.csv',
-                         2: 'ven3_test.csv', 3: 'plannet_test.csv'},
-            'FIRSTROW': {0: 0, 1: 0, 2: 0, 3: 0},
-            'LASTROW': {0: 0, 1: 0, 2: 0, 3: 0},
-            'Full Placement Name': {
-                0: '::Campaign Name|Ad Set Name|Ad Name',
-                1: '::Campaign|Ad group|Ad',
-                2: 'Placement Name',
-                3: 'mpCampaign|mpVendor'},
-            'Placement Name': {0: 'Ad Name', 1: 'Ad', 2: 'Placement Name',
-                               3: 'mpVendor'},
-            'FILENAME_DICTIONARY': {0: 'ven1_dictionary_test.csv',
-                                    1: 'ven2_dictionary_test.csv',
-                                    2: 'ven3_dictionary_test.csv',
-                                    3: 'plannet_dictionary.csv'},
-            'FILENAME_ERROR': {0: 'VEN1_ERROR_REPORT.csv',
-                               1: 'VEN2_ERROR_REPORT.csv',
-                               2: 'VEN3_ERROR_REPORT.csv',
-                               3: 'PLANNET_ERROR_REPORT.csv'},
-            'START DATE': {0: '10/7/2024', 1: '10/7/2024',
-                           2: '10/10/2024', 3: ''},
-            'END DATE': {0: '', 1: '', 2: '', 3: ''},
-            'DROP_COLUMNS': {0: 'ALL', 1: 'ALL', 2: 'ALL', 3: 'ALL'},
-            'AUTO DICTIONARY PLACEMENT': {0: 'Full Placement Name',
-                                          1: 'Full Placement Name',
-                                          2: 'Full Placement Name',
-                                          3: 'Full Placement Name'},
-            'AUTO DICTIONARY ORDER': {
-                0: 'mpBudget|mpVendor|mpCountry/Region|mpCampaign',
-                1: 'mpMisc|mpBudget|mpVendor|mpCountry/Region|mpCampaign',
-                2: 'mpMisc|mpBudget|mpVendor|mpCountry/Region|mpCampaign',
-                3: ''},
-            'API_FILE': {0: 'ven1_config_test.json',
-                         1: 'ven2_config_test.yaml',
-                         2: 'ven3_config_test.json', 3: ''}
-        }
-        for key in vmc.datacol + vmc.vmkeys:
-            if key not in vm_dict:
-                vm_dict[key] = {0: '', 1: '', 2: '', 3: ''}
-        vm_df = pd.DataFrame(vm_dict)
-        return vm_df
-
+        self.vm_df = self.generate_test_vm(vm_dict, 4)
+        return self.vm_df
+        
     def test_double_fix_all_raw(self, test_vm):
         """
         If test is failing due to Vendor Key errors, ensure 'Vendormatrix.csv'
@@ -864,10 +810,35 @@ class TestAnalyze:
         """
 
     @pytest.fixture
-    def setup_autodict_files(self, test_vm2):
-        """ Creates ven1_test.csv,ven2_test.csv, ven3_test.csv, and
+    def setup_autodict_files(self):
+        """
+        Generates test vendormatrix for autodictionary order.
+        Creates ven1_test.csv, ven2_test.csv, ven3_test.csv, and
         plannet_test.csv in the raw_data folder and populates them with data
-        that should trigger new order suggestions for test_autodict_analysis. """
+        that should trigger new order suggestions for test_autodict_analysis.
+
+        :returns: test vendormatrix as a dataframe
+        """
+        vm_dict = {
+            vmc.vendorkey:
+                {0: 'API_Ven1_Test', 1: 'API_Ven2_Test',
+                 2: 'API_Ven3_Test', 3: 'Plan Net'},
+            vmc.filename: {0: 'ven1_test.csv', 1: 'ven2_test.csv',
+                           2: 'ven3_test.csv', 3: 'plannet_test.csv'},
+            vmc.fullplacename: {
+                0: '::Campaign Name|Ad Set Name|Ad Name',
+                1: '::Campaign|Ad group|Ad',
+                2: 'Placement Name',
+                3: 'mpCampaign|mpVendor'},
+            vmc.placement: {0: 'Ad Name', 1: 'Ad',
+                            2: 'Placement Name', 3: 'mpVendor'},
+            vmc.autodicord: {
+                0: 'mpBudget|mpVendor|mpCountry/Region|mpCampaign',
+                1: 'mpMisc|mpBudget|mpVendor|mpCountry/Region|mpCampaign',
+                2: 'mpMisc|mpBudget|mpVendor|mpCountry/Region|mpCampaign',
+                3: ''}
+        }
+        test_vm = self.generate_test_vm(vm_dict, 4)
         data1 = {
             'Campaign Name':
                 {0: 'Campaign 1', 1: 'Campaign 2'},
@@ -902,15 +873,15 @@ class TestAnalyze:
                  4: 'Vendor2', 5: 'Vendor1', 6: 'Vendor3'},
         }
         files_to_write = {
-            test_vm2[vmc.filename][0]: pd.DataFrame(data1),
-            test_vm2[vmc.filename][1]: pd.DataFrame(data2),
-            test_vm2[vmc.filename][2]: pd.DataFrame(data3),
-            test_vm2[vmc.filename][3]: pd.DataFrame(plannet_data)
+            test_vm[vmc.filename][0]: pd.DataFrame(data1),
+            test_vm[vmc.filename][1]: pd.DataFrame(data2),
+            test_vm[vmc.filename][2]: pd.DataFrame(data3),
+            test_vm[vmc.filename][3]: pd.DataFrame(plannet_data)
         }
         for filename in files_to_write:
             files_to_write[filename].to_csv('raw_data/{}'.format(filename),
                                             index=False)
-        return test_vm2
+        return test_vm
 
     def test_autodict_analysis(self, setup_autodict_files):
         """
@@ -919,10 +890,15 @@ class TestAnalyze:
         position (Ven1 test), a positive shift via Campaign position (Ven2
         test), and a negative shift via Vendor position (Ven3 test) for the
         suggested orders.
+        
         'positive shift' = suggests shifting order to the right by appending
         'mpMisc' cells to the start of the list
         'negative shift' = suggests shifting order cell to the left by removing
         cells from the start of the list
+
+        
+        :param setup_autodict_files: Fixture that sets up data files and
+        returns the vendormatrix for this test
         """
         vm_dict = setup_autodict_files
         matrix = vm.VendorMatrix()


### PR DESCRIPTION
- Added plan net vendor names to the list it's looking at
- Incorporated plan net campaign names in the order check 
- Created test for CheckAutoDictOrder adjustments based on vendor and campaign