### PR TITLE
add col to AmzApi

### DIFF
--- a/reporting/amzapi.py
+++ b/reporting/amzapi.py
@@ -31,7 +31,8 @@ class AmzApi(object):
         'date', 'impressions', 'clicks', 'cost', 'campaignName', 'campaignId']
     sp_columns = [
         'spend', 'purchases14d', 'purchasesSameSku14d', 'unitsSoldClicks14d',
-        'sales14d', 'attributedSalesSameSku14d', 'adGroupName', 'adGroupId']
+        'unitsSoldSameSku14d', 'sales14d', 'attributedSalesSameSku14d',
+        'adGroupName', 'adGroupId']
     sb_columns = [
         'detailPageViewsClicks', 'newToBrandDetailPageViews',
         'newToBrandDetailPageViewsClicks', 'newToBrandPurchases',


### PR DESCRIPTION
per request to add to Amazon API:
- unitsSoldSameSku14d: added to sp_columns
- unitsSold14d: only available for report type sbPurchasedProduct, which we do not pull
- unitsSold: already included