### PR TITLE
Vm rules bug fix

### DIFF
--- a/reporting/vendormatrix.py
+++ b/reporting/vendormatrix.py
@@ -168,12 +168,15 @@ class VendorMatrix(object):
                 else:
                     new_value = ''
                 self.vm_change(index, col, new_value)
-            # for i, rule in source['vm_rules'].items():
-            #     for key, val in rule.items():
-            #         col = 'RULE_{}_{}'.format((int(i) + 1), key)
-            #         if col == val:
-            #             continue
-            #         self.vm_change(index, col, val)
+            for i, rule in source['vm_rules'].items():
+                for key, val in rule.items():
+                    col = 'RULE_{}_{}'.format(i, key)
+                    default = col.split(i)
+                    post_def = 'POST::{}'.format(default[0])
+                    if val.startswith(default[0]) or val.startswith(post_def):
+                        if val.endswith(default[1]):
+                            continue
+                    self.vm_change(index, col, val)
         self.write()
 
     def get_import_data_sources(self, import_type='API_', default_param=None):


### PR DESCRIPTION
Change default value check to include 'POST::' variant and not require matching rule number: just checks the value doesn't start with 'RULE_' or 'POST::RULE_' AND end in '_METRIC'/'_FACTOR'/'_QUERY' to help with catching unwanted overwrites to the VM (reporting/vendormatrix.py)