### PR TITLE
Price list

### DIFF
--- a/reporting/vendormatrix.py
+++ b/reporting/vendormatrix.py
@@ -1144,6 +1144,54 @@ def df_single_transform(df, transform):
             df[col] = df[col].map(
                 lambda x: urllib.parse.unquote(
                     x, encoding='utf-8', errors='replace'))
+    if transform_type == 'PriceCalculate':
+        count_suffix = ' Count'
+        prefix_filter = 'Purchase - '
+        # transform[1:] are 'product|price' pairs, e.g.
+        # PriceCalculate::Purchase - GW2 POF|19.49::Purchase - EOD Deluxe|35.74
+        # Keyed case-insensitively; blank/invalid price -> product is unpriced.
+        prices = {}
+        for pair in transform[1:]:
+            if pair.count('|') != 1:
+                log.warning('{}: ignoring "{}" (expected one "product|price" '
+                            'pair).'.format(transform_type, pair))
+                continue
+            product, price = pair.split('|')
+            product, price = product.strip().lower(), price.strip()
+            if not price:
+                continue  # blank price: product intentionally left unpriced
+            price = pd.to_numeric(price, errors='coerce')
+            if product and pd.notna(price):
+                prices[product] = float(price)
+            else:
+                log.warning('{}: ignoring "{}" (invalid product or price).'
+                            .format(transform_type, pair))
+        # Find every purchase Count column. We scan the data (not just the
+        # priced products) because 'Gamesight purchases' below counts purchases
+        # that have no price too.
+        purchase_count_cols = [c for c in df.columns
+                               if str(c).startswith(prefix_filter)
+                               and str(c).endswith(count_suffix)]
+        # For each product that has a price, add a '<product> Revenue' column
+        # (count * unit price) directly after its Count column.
+        revenue_cols = []
+        for count_col in purchase_count_cols:
+            product = count_col[:-len(count_suffix)]
+            price = prices.get(product.lower())
+            if price is None:
+                continue
+            revenue_col = product + ' Revenue'
+            counts = pd.to_numeric(df[count_col], errors='coerce').fillna(0)
+            df.insert(df.columns.get_loc(count_col) + 1, revenue_col,
+                      (counts * price).round(2))
+            revenue_cols.append(revenue_col)
+        # Total revenue: add up every product's revenue column.
+        df['Revenue'] = (df[revenue_cols].sum(axis=1).round(2)
+                         if revenue_cols else 0.0)
+        # Total purchases: add up every purchase Count column, priced or not.
+        df['Gamesight purchases'] = (
+            df[purchase_count_cols].apply(pd.to_numeric, errors='coerce')
+            .fillna(0).sum(axis=1) if purchase_count_cols else 0)
     return df
 
 

--- a/reporting/vendormatrix.py
+++ b/reporting/vendormatrix.py
@@ -1147,9 +1147,6 @@ def df_single_transform(df, transform):
     if transform_type == 'PriceCalculate':
         count_suffix = ' Count'
         prefix_filter = 'Purchase - '
-        # transform[1:] are 'product|price' pairs, e.g.
-        # PriceCalculate::Purchase - GW2 POF|19.49::Purchase - EOD Deluxe|35.74
-        # Keyed case-insensitively; blank/invalid price -> product is unpriced.
         prices = {}
         for pair in transform[1:]:
             if pair.count('|') != 1:
@@ -1159,21 +1156,16 @@ def df_single_transform(df, transform):
             product, price = pair.split('|')
             product, price = product.strip().lower(), price.strip()
             if not price:
-                continue  # blank price: product intentionally left unpriced
+                continue
             price = pd.to_numeric(price, errors='coerce')
             if product and pd.notna(price):
                 prices[product] = float(price)
             else:
                 log.warning('{}: ignoring "{}" (invalid product or price).'
                             .format(transform_type, pair))
-        # Find every purchase Count column. We scan the data (not just the
-        # priced products) because 'Gamesight purchases' below counts purchases
-        # that have no price too.
         purchase_count_cols = [c for c in df.columns
                                if str(c).startswith(prefix_filter)
                                and str(c).endswith(count_suffix)]
-        # For each product that has a price, add a '<product> Revenue' column
-        # (count * unit price) directly after its Count column.
         revenue_cols = []
         for count_col in purchase_count_cols:
             product = count_col[:-len(count_suffix)]
@@ -1185,10 +1177,8 @@ def df_single_transform(df, transform):
             df.insert(df.columns.get_loc(count_col) + 1, revenue_col,
                       (counts * price).round(2))
             revenue_cols.append(revenue_col)
-        # Total revenue: add up every product's revenue column.
         df['Revenue'] = (df[revenue_cols].sum(axis=1).round(2)
                          if revenue_cols else 0.0)
-        # Total purchases: add up every purchase Count column, priced or not.
         df['Gamesight purchases'] = (
             df[purchase_count_cols].apply(pd.to_numeric, errors='coerce')
             .fillna(0).sum(axis=1) if purchase_count_cols else 0)

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -466,6 +466,23 @@ class TestVendormatrix:
         cpc_calc = df[df[dctc.AM] == cal.BM_CPC][vmc.AD_COST].to_list()[0]
         assert cpc_cost == cpc_calc
 
+    def test_price_calculate_transform(self):
+        df = pd.DataFrame({
+            'Campaign': ['row_a', 'row_b'],
+            'Purchase - Priced Item Count': [2, 0],    # priced
+            'Purchase - Unpriced Item Count': [5, 1],  # listed, blank price -> none
+            'Download - Other Item Count': [9, 9],     # ' Count' but not 'Purchase - '
+        })
+        transform = ('PriceCalculate::purchase - priced item|19.49'
+                     '::Purchase - Unpriced Item|')
+        out = vm.df_transform(df, transform)
+        assert out['Purchase - Priced Item Revenue'].tolist() == [38.98, 0.0]
+        assert 'Purchase - Unpriced Item Revenue' not in out.columns
+        assert out['Revenue'].tolist() == [38.98, 0.0]
+        assert out['Gamesight purchases'].tolist() == [7, 1]
+        assert out['Download - Other Item Count'].tolist() == [9, 9]
+        assert 'Download - Other Item Revenue' not in out.columns
+
     @requires_base_config
     def test_vm_load(self):
         matrix = vm.VendorMatrix()


### PR DESCRIPTION
Adds a new, config-driven TRANSFORM type that calculates revenue from purchase-count columns. Used as PriceCalculate::<product>|<price>::<product>|<price>… in a datasource's TRANSFORM cell.                                                                                                             
                                                                                                                                                                                                                                                                                                            
  - Parses inline product|price pairs from the transform args into a price lookup. Product names are matched case-insensitively (stripped + lowercased); prices are coerced with pd.to_numeric.                                                                                                             
  - Validates input and warns instead of failing silently — a pair without exactly one | (missing or extra pipe), or a non-numeric price, is logged and skipped. A deliberately blank price is allowed and just leaves that product unpriced.                                                               
  - Computes per-product revenue — for every Purchase - * Count column that has a price, inserts a <product> Revenue column (count × price, rounded) directly after its count column.                                                                                                                       
  - Adds two totals:                                                                                                                                                                                                                                                                                        
    - Revenue — sum of all per-product revenue columns (priced products only).                                                                                                                                                                                                                              
    - Gamesight purchases — sum of every Purchase - * Count column, priced or not.                                                                                                                                                                                                                          
  - Column conventions ( Count suffix, Purchase -  prefix) are carried over unchanged from the original standalone revenue script, so output matches it byte-for-byte (verified against its _processed.csv reference files).