### PR TITLE
Ensure df col is all strings before calling .str

### DIFF
--- a/reporting/analyze.py
+++ b/reporting/analyze.py
@@ -1349,6 +1349,7 @@ class CheckAutoDictOrder(AnalyzeBase):
             msg = 'contains NaN, suggest choosing different placement column'
             logging.warning('{} {}]'.format(auto_place, msg))
             tdf[auto_place] = tdf[auto_place].astype(str)
+        tdf = utl.data_to_type(tdf, str_col=[auto_place])
         tdf = pd.DataFrame(tdf[auto_place].str.split('_').to_list())
         ven_raw_idx = self.get_raw_data_vendor_idx(tdf, camp_shift, ven_list,
                                                    cou_list, camp_list)

--- a/reporting/dictionary.py
+++ b/reporting/dictionary.py
@@ -64,6 +64,7 @@ class Dict(object):
         error = err.get()
         error.columns = [dctc.FPN, dctc.PN]
         if include_full_name:
+            error = utl.data_to_type(error, str_col=[placement])
             max_placement_name_length = max(
                 map(len, error[placement].str.split('_')))
             if len(autodicord) < max_placement_name_length:


### PR DESCRIPTION
add data_to_type() before calling .str on a df column to prevent type errors (reporting/analyze.py, reporting/dictionary.py) - tickets [#851](https://lqadata.com/tickets/851) and [#852](https://lqadata.com/tickets/852)